### PR TITLE
Fix Flinch Lizards from causing a dupe bug.

### DIFF
--- a/main/java/net/daveyx0/multimob/entity/ai/EntityAIStealFromPlayer.java
+++ b/main/java/net/daveyx0/multimob/entity/ai/EntityAIStealFromPlayer.java
@@ -165,7 +165,7 @@ public class EntityAIStealFromPlayer extends EntityAIBase {
 							
 							this.temptingPlayer.playSound(SoundEvents.ENTITY_CHICKEN_EGG, 1.0F, (world.rand.nextFloat() - world.rand.nextFloat()) * 0.2F + 1.0F);
 		
-							ItemStack loot = item.copy();
+							ItemStack loot = item.split(1);
 							this.temptedEntity.setItemStackToSlot(EntityEquipmentSlot.MAINHAND, loot);
 							
 		    				if(!temptingPlayer.capabilities.isCreativeMode)


### PR DESCRIPTION
Flinch Lizards copy the entire stack of items rather than just taking a single item from the stack, this is causing a pretty intense dupe bug when you kill them.
This change should make sure the lizard is only holding 1 item when it copies the stack from the player.

Disclaimer: I have not tested this, I just made this edit on github